### PR TITLE
[EMULATOR] Fix arrow keymapping

### DIFF
--- a/hal/sim/input.py
+++ b/hal/sim/input.py
@@ -7,9 +7,9 @@ import pygame
 # Key mapping from PC keyboard to CardKB codes
 KEY_MAP = {
     # Arrow keys
-    pygame.K_UP: 0xB4,      # Up arrow
-    pygame.K_DOWN: 0xB5,    # Down arrow
-    pygame.K_LEFT: 0xB6,    # Left arrow
+    pygame.K_UP: 0xB5,      # Up arrow
+    pygame.K_DOWN: 0xB6,    # Down arrow
+    pygame.K_LEFT: 0xB4,    # Left arrow
     pygame.K_RIGHT: 0xB7,   # Right arrow
     
     # Special keys


### PR DESCRIPTION
They keymap was incorrect for the arrows. Keymapping info from original source:

![](https://static-cdn.m5stack.com/resource/docs/products/unit/cardkb/cardkb_02.webp)